### PR TITLE
Dc-634 Fix steps order

### DIFF
--- a/src/components/githubIssuesListSection.js
+++ b/src/components/githubIssuesListSection.js
@@ -50,8 +50,13 @@ class GithubIssuesListSection extends Component {
     const platforms = elements.platform_selector_nodes.map(platform =>
       <option key={platform.elements.codename.value} value={platform.elements.codename.value}>{platform.elements.name.value}</option>);
 
+    // TODO remove and use node.elements.sections_nodes when https://github.com/Kentico/gatsby-source-kentico-cloud/issues/30 fixed
+    const stepsOrderingPattern = elements.steps.map(item => item.system.id);
     const steps = elements.steps_nodes
       .filter(step => step.elements.persona[0].system.codename === this.props.currentPersona)
+      .sort((a, b) => {
+        return stepsOrderingPattern.indexOf(a.system.id) - stepsOrderingPattern.indexOf(b.system.id)
+      })
       .map((step, index) =>
         <div key={index}>
           <span>{("0" + (index + 1)).slice(-2)}/</span>
@@ -92,7 +97,7 @@ class GithubIssuesListSection extends Component {
       {platforms}
     </select>);
 
-    const selectedPlatforms = elements.platform_selector_nodes.filter(({elements}) => elements.codename.value === this.state.platformSelection);
+    const selectedPlatforms = elements.platform_selector_nodes.filter(({ elements }) => elements.codename.value === this.state.platformSelection);
     const selectedPlatformLink = selectedPlatforms.length > 0 &&
       selectedPlatforms[0].elements.detail_url.text &&
       <a className="btn" href={selectedPlatforms[0].elements.detail_url.text} target="_blank" rel="noopener noreferrer">Public backlog</a>;
@@ -145,6 +150,7 @@ GithubIssuesListSection.propTypes = {
       section_info__background_image: PropTypes.object,
       platform_selector_nodes: PropTypes.array,
       steps_label: PropTypes.object,
+      steps: PropTypes.array,
       steps_nodes: PropTypes.array,
       issues_label: PropTypes.object,
     })

--- a/src/components/landingPage.js
+++ b/src/components/landingPage.js
@@ -151,7 +151,15 @@ class LandingPage extends Component {
                             url
                           }
                         }
+                        steps {
+                          system {
+                            id
+                          }
+                        }
                         steps_nodes {
+                          system {
+                            id
+                          }
                           elements {
                             persona {
                               system {


### PR DESCRIPTION
### Motivation

According to the bug: https://github.com/Kentico/gatsby-source-kentico-cloud/issues/30
It is required to sort all linked items manually: - after the issue is fixed we have the issue submitted - #13 

This pull request implement sorting for steps in Github Issue List section

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) has been reverted to defaults

### How to test

Check that steps order is according the one in Kentico Cloud App UI.