### PR TITLE
Use different strategy for local assets

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = {
           },
           {
             urlPattern: /^https:\/\/kentico.github.io/,
-            handler: 'staleWhileRevalidate',
+            handler: 'networkFirst',
             options: {
               cacheableResponse: {
                 statuses: [0, 200]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6690,7 +6690,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kentico-github-io",
   "description": "Official landing page for developer community in Kentico",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": "Ondřej Chrastina <developerscommunity@kentico.com> (https://github.com/Simply007)",
   "scripts": {
     "build": "gatsby build && cpx -v \".github/**/*\" public/.github && cpx CODE_OF_CONDUCT.md public && cpx CONTRIBUTING.md public && cpx README.md public && cpx LICENSE public",


### PR DESCRIPTION
### Motivation

Reconfigure the offline plugin to use the latest version of the local data deployed on Github pages to prevent scenario:

Ee release a new version of the page (i.e. with new section). First load return old version (without the newest data).
